### PR TITLE
Update Terraform to 1.x syntax

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -3,21 +3,20 @@ data "aws_ami" "example_ami" {
   most_recent = true
 
   filter {
-    name = "name"
-
+    name   = "name"
     values = ["example*"]
   }
 
-  owners = ["${var.aws_account_id}"]
+  owners = [var.aws_account_id]
 }
 
 # Create EC2 instances
 resource "aws_instance" "example" {
-  ami                    = "${data.aws_ami.example_ami.id}"
-  instance_type          = "${var.default_instance_type}"
-  vpc_security_group_ids = ["${aws_security_group.example.id}"]
-  subnet_id              = "${aws_subnet.subnet-1a.id}"
-  key_name               = "${aws_key_pair.pem-key.key_name}"
+  ami                    = data.aws_ami.example_ami.id
+  instance_type          = var.default_instance_type
+  vpc_security_group_ids = [aws_security_group.example.id]
+  subnet_id              = aws_subnet.subnet-1a.id
+  key_name               = aws_key_pair.pem-key.key_name
 
   tags = {
     Name = "example"

--- a/terraform/internet_gateway.tf
+++ b/terraform/internet_gateway.tf
@@ -1,5 +1,5 @@
 resource "aws_internet_gateway" "internet-gateway" {
-  vpc_id = "${aws_vpc.example.id}"
+  vpc_id = aws_vpc.example.id
 
   tags = {
     Name = "example"

--- a/terraform/key-pair.tf
+++ b/terraform/key-pair.tf
@@ -1,4 +1,4 @@
 resource "aws_key_pair" "pem-key" {
   key_name   = "example"
-  public_key = "${file("files/id_rsa.pub")}"
+  public_key = file("files/id_rsa.pub")
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,4 +1,4 @@
 output "public_dns" {
   description = "The EC2 instance DNS"
-  value       = "${aws_instance.example.public_dns}"
+  value       = aws_instance.example.public_dns
 }

--- a/terraform/route53_route.tf
+++ b/terraform/route53_route.tf
@@ -1,7 +1,7 @@
 resource "aws_route53_record" "example_cname" {
-  zone_id = "${aws_route53_zone.example_zone.zone_id}"
+  zone_id = aws_route53_zone.example_zone.zone_id
   name    = "www.myexample.com"
   type    = "CNAME"
   ttl     = "60"
-  records = ["${aws_instance.example.public_dns}"]
+  records = [aws_instance.example.public_dns]
 }

--- a/terraform/route_table.tf
+++ b/terraform/route_table.tf
@@ -1,5 +1,5 @@
 resource "aws_route_table" "route-table" {
-  vpc_id = "${aws_vpc.example.id}"
+  vpc_id = aws_vpc.example.id
 
   tags = {
     Name = "example"
@@ -7,8 +7,7 @@ resource "aws_route_table" "route-table" {
 }
 
 resource "aws_route" "route-table" {
-  route_table_id         = "${aws_route_table.route-table.id}"
+  route_table_id         = aws_route_table.route-table.id
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.internet-gateway.id}"
-  depends_on             = ["aws_route_table.route-table"]
+  gateway_id             = aws_internet_gateway.internet-gateway.id
 }

--- a/terraform/route_table_association.tf
+++ b/terraform/route_table_association.tf
@@ -1,9 +1,9 @@
 resource "aws_route_table_association" "route-table-a" {
-  subnet_id      = "${aws_subnet.subnet-1a.id}"
-  route_table_id = "${aws_route_table.route-table.id}"
+  subnet_id      = aws_subnet.subnet-1a.id
+  route_table_id = aws_route_table.route-table.id
 }
 
 resource "aws_route_table_association" "route-table-b" {
-  subnet_id      = "${aws_subnet.subnet-1b.id}"
-  route_table_id = "${aws_route_table.route-table.id}"
+  subnet_id      = aws_subnet.subnet-1b.id
+  route_table_id = aws_route_table.route-table.id
 }

--- a/terraform/security-group.tf
+++ b/terraform/security-group.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "example" {
   name        = "example"
   description = "example security group"
-  vpc_id      = "${aws_vpc.example.id}"
+  vpc_id      = aws_vpc.example.id
 
   tags = {
     Name = "example"

--- a/terraform/security_group_rules.tf
+++ b/terraform/security_group_rules.tf
@@ -4,7 +4,7 @@ resource "aws_security_group_rule" "example" {
   to_port           = 80
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.example.id}"
+  security_group_id = aws_security_group.example.id
   description       = "Public HTTP"
 }
 
@@ -12,8 +12,8 @@ resource "aws_security_group_rule" "example_egress" {
   type              = "egress"
   from_port         = 0
   to_port           = 0
-  protocol          = "all"
+  protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.example.id}"
+  security_group_id = aws_security_group.example.id
   description       = "Allow all out"
 }

--- a/terraform/subnets.tf
+++ b/terraform/subnets.tf
@@ -1,8 +1,7 @@
 resource "aws_subnet" "subnet-1a" {
-  vpc_id                  = "${aws_vpc.example.id}"
+  vpc_id                  = aws_vpc.example.id
   availability_zone       = "eu-west-1a"
   cidr_block              = "100.10.0.0/20"
-  ipv6_cidr_block         = ""
   map_public_ip_on_launch = "true"
 
   tags = {
@@ -11,11 +10,9 @@ resource "aws_subnet" "subnet-1a" {
 }
 
 resource "aws_subnet" "subnet-1b" {
-  vpc_id = "${aws_vpc.example.id}"
-
+  vpc_id                  = aws_vpc.example.id
   availability_zone       = "eu-west-1b"
   cidr_block              = "100.10.16.0/20"
-  ipv6_cidr_block         = ""
   map_public_ip_on_launch = "true"
 
   tags = {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,27 +1,27 @@
 # Variables used
 variable "aws_account_id" {
   // read from terraform.tfvars
-  type = "string"
+  type = string
 }
 
 variable "default_instance_type" {
   // read from terraform.tfvars
-  type = "string"
+  type = string
 }
 
 variable "default_region" {
   // read from terraform.tfvars
-  type = "string"
+  type = string
 }
 
 variable "apply_immediately" {
   // read from terraform.tfvars
-  type    = "string"
+  type    = string
   default = "false"
 }
 
 variable "encryption_at_rest" {
   // read from terraform.tfvars
-  type    = "string"
+  type    = string
   default = "true"
 }


### PR DESCRIPTION
Closes #6

Brings the Terraform up to current syntax so it parses on 1.x:
- quoted type constraints dropped (`type = string`)
- `${...}` interpolation removed from plain references
- `depends_on` switched to the reference-list form (and dropped where redundant)
- the invalid empty `ipv6_cidr_block` removed from the subnets

`terraform fmt -check` passes. The remaining provider `shared_credentials_file` error is handled in #4.