### PR TITLE
Pin Terraform and AWS provider versions

### DIFF
--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
Closes #3

Adds a `terraform {}` block with `required_version = ">= 1.0"` and a pinned `required_providers` (aws ~> 5.0) so the provider version is reproducible.