### PR TITLE
Read region and credentials from the environment

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,6 @@
+# Credentials and profile come from the environment (AWS_PROFILE / the
+# standard AWS credential chain). Region defaults to eu-west-1 but can be
+# overridden with the region variable or AWS_REGION.
 provider "aws" {
-  region                  = "eu-west-1"
-  shared_credentials_file = "~/.aws/credentials"
-  profile                 = "example"
+  region = var.region
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,4 +1,10 @@
 # Variables used
+variable "region" {
+  // AWS region to deploy into; also honours AWS_REGION
+  type    = string
+  default = "eu-west-1"
+}
+
 variable "aws_account_id" {
   // read from terraform.tfvars
   type = string


### PR DESCRIPTION
Closes #4

The provider no longer hardcodes `shared_credentials_file` (removed in AWS provider 5.x) or `profile = "example"`; it uses the standard credential chain (`AWS_PROFILE`/`AWS_REGION`). Region comes from a new `region` variable defaulting to eu-west-1.

`terraform validate` now passes.