### PR TITLE
Add tflint config with the AWS ruleset

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,14 @@
+config {
+  call_module_type = "all"
+}
+
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}
+
+plugin "aws" {
+  enabled = true
+  version = "0.32.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}


### PR DESCRIPTION
Closes #15

Adds `.tflint.hcl` enabling the recommended terraform preset and the AWS ruleset. Wired into the Makefile and CI in the related scaffolding issues.