### PR TITLE
Add CI workflow to test pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: terraform-linters/setup-tflint@v4
-      - run: tflint --init
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - run: tflint --init --config="$GITHUB_WORKSPACE/.tflint.hcl"
         working-directory: terraform
-      - run: tflint --config=${{ github.workspace }}/.tflint.hcl
+      - run: tflint --config="$GITHUB_WORKSPACE/.tflint.hcl"
         working-directory: terraform
 
   # Non-blocking until the Ansible roles are modernised (milestone 3).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  terraform:
+    name: terraform
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: terraform
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.10.5
+      - name: fmt
+        run: terraform fmt -check -recursive
+      - name: init
+        run: terraform init -backend=false -input=false
+      - name: validate
+        run: terraform validate
+
+  tflint:
+    name: tflint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: terraform-linters/setup-tflint@v4
+      - run: tflint --init
+        working-directory: terraform
+      - run: tflint --config=${{ github.workspace }}/.tflint.hcl
+        working-directory: terraform
+
+  # Non-blocking until the Ansible roles are modernised (milestone 3).
+  ansible-lint:
+    name: ansible-lint
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ansible-lint
+      - run: ansible-lint
+        working-directory: ansible
+
+  # Non-blocking until the template is converted to HCL2 (milestone 3).
+  packer-validate:
+    name: packer-validate
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-packer@v3
+      - run: packer init . && packer validate .
+        working-directory: packer


### PR DESCRIPTION
Closes #13

Adds `.github/workflows/ci.yml`. The `terraform` job (fmt -check + init + validate) is the gate; `tflint` runs too. `ansible-lint` and `packer-validate` run but are non-blocking until milestone 3 modernises the Ansible roles and converts Packer to HCL2.