### PR TITLE
Add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+This is a small demo project, but if you spot a security problem please report
+it privately rather than opening a public issue.
+
+## Reporting a vulnerability
+
+Open a [private security advisory](https://github.com/gordonmurray/packer_ansible_inspec_terraform_aws/security/advisories/new),
+or email gordon@gordonmurray.ie.
+
+## Scope
+
+The Terraform here builds a deliberately simple, public "hello world" web
+server: HTTP is open to the world by design and there is no TLS. Treat anything
+you deploy from this repo as a throwaway demo, not a production baseline.


### PR DESCRIPTION
Closes #16

A short SECURITY.md: how to report privately, and a note that the demo opens HTTP to the world by design and isn't a production baseline.