### PR TITLE
Encrypt the EC2 root volume

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -18,6 +18,10 @@ resource "aws_instance" "example" {
   subnet_id              = aws_subnet.subnet-1a.id
   key_name               = aws_key_pair.pem-key.key_name
 
+  root_block_device {
+    encrypted = true
+  }
+
   tags = {
     Name = "example"
   }


### PR DESCRIPTION
Closes #18

Adds a `root_block_device` with `encrypted = true` to the instance.