### PR TITLE
Require IMDSv2 on the instance

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -22,6 +22,10 @@ resource "aws_instance" "example" {
     encrypted = true
   }
 
+  metadata_options {
+    http_tokens = "required"
+  }
+
   tags = {
     Name = "example"
   }


### PR DESCRIPTION
Closes #19

Adds `metadata_options { http_tokens = "required" }` so the instance metadata service requires session tokens.