### PR TITLE
Add an optional SSH ingress rule

### DIFF
--- a/terraform/security_group_rules.tf
+++ b/terraform/security_group_rules.tf
@@ -8,6 +8,17 @@ resource "aws_security_group_rule" "example" {
   description       = "Public HTTP"
 }
 
+resource "aws_security_group_rule" "ssh" {
+  count             = var.ssh_cidr == "" ? 0 : 1
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = [var.ssh_cidr]
+  security_group_id = aws_security_group.example.id
+  description       = "SSH"
+}
+
 resource "aws_security_group_rule" "example_egress" {
   type              = "egress"
   from_port         = 0

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -11,3 +11,6 @@ default_instance_type = "t2.nano"
 
 # Public key for the EC2 key pair; defaults to ~/.ssh/id_rsa.pub
 # ssh_public_key_path = "~/.ssh/id_rsa.pub"
+
+# Optional: open SSH (port 22) to this CIDR only. Empty means no SSH rule.
+# ssh_cidr = "203.0.113.4/32"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -20,3 +20,9 @@ variable "ssh_public_key_path" {
   type    = string
   default = "~/.ssh/id_rsa.pub"
 }
+
+variable "ssh_cidr" {
+  // CIDR allowed to SSH in; empty means no SSH rule is created
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
Closes #21

Adds an `ssh_cidr` variable (empty by default). When set, it opens port 22 to just that CIDR via a counted security group rule; left empty, no SSH rule is created.