### PR TITLE
Install Ansible from the distro instead of the PPA

### DIFF
--- a/packer/server.pkr.hcl
+++ b/packer/server.pkr.hcl
@@ -52,9 +52,8 @@ build {
 
   provisioner "shell" {
     inline = [
-      "sudo apt-add-repository ppa:ansible/ansible",
-      "sudo apt update",
-      "sudo apt install ansible -y",
+      "sudo apt-get update",
+      "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ansible",
     ]
   }
 


### PR DESCRIPTION
Closes #24

Ubuntu 24.04 ships Ansible in universe, so the `ppa:ansible/ansible` step is gone; Ansible is installed with `apt-get` before the ansible-local provisioner runs.