### PR TITLE
Use FQCN module names in the Ansible roles

### DIFF
--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -2,12 +2,12 @@
   vars:
     packages:
       - nginx-core
-  apt:
+  ansible.builtin.apt:
     pkg: "{{ packages }}"
-    update_cache: yes
+    update_cache: true
     state: latest
 
 - name: Delete the default nginx landing page
-  file:
+  ansible.builtin.file:
     path: /var/www/html/index.nginx-debian.html
     state: absent

--- a/ansible/roles/permissions/tasks/main.yml
+++ b/ansible/roles/permissions/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Set /var/www ownership
-  file:
+  ansible.builtin.file:
     path: /var/www
     state: directory
-    recurse: yes
+    recurse: true
     owner: ubuntu
     group: ubuntu

--- a/ansible/roles/php/tasks/main.yml
+++ b/ansible/roles/php/tasks/main.yml
@@ -5,7 +5,7 @@
       - php-fpm
       - php-cli
       - php-curl
-  apt:
+  ansible.builtin.apt:
     pkg: "{{ packages }}"
-    update_cache: yes
+    update_cache: true
     state: latest

--- a/ansible/server.yml
+++ b/ansible/server.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install Nginx, PHP and set folder permissions
   hosts: all
-  become: yes
+  become: true
 
   roles:
     - nginx


### PR DESCRIPTION
Closes #25

Uses `ansible.builtin.apt`/`ansible.builtin.file` and tidies the YAML (`true` over `yes`, trailing newlines). Only the `package-latest` lint warning remains, which is handled in #28.