### PR TITLE
Pin Ansible package state

### DIFF
--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -1,11 +1,8 @@
 - name: Install Nginx
-  vars:
-    packages:
-      - nginx-core
   ansible.builtin.apt:
-    pkg: "{{ packages }}"
+    name: nginx
     update_cache: true
-    state: latest
+    state: present
 
 - name: Delete the default nginx landing page
   ansible.builtin.file:

--- a/ansible/roles/php/tasks/main.yml
+++ b/ansible/roles/php/tasks/main.yml
@@ -1,11 +1,9 @@
 - name: Install PHP and some related packages
-  vars:
-    packages:
+  ansible.builtin.apt:
+    name:
       - php
       - php-fpm
       - php-cli
       - php-curl
-  ansible.builtin.apt:
-    pkg: "{{ packages }}"
     update_cache: true
-    state: latest
+    state: present


### PR DESCRIPTION
Closes #28

Installs with `state: present` instead of `latest` so builds are reproducible, and uses `nginx` rather than the `nginx-core` meta-package. ansible-lint is now clean.