### PR TITLE
Template the nginx PHP-FPM socket from the installed version

### DIFF
--- a/ansible/roles/nginx/handlers/main.yml
+++ b/ansible/roles/nginx/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: Reload nginx
+  ansible.builtin.service:
+    name: nginx
+    state: reloaded

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -8,3 +8,17 @@
   ansible.builtin.file:
     path: /var/www/html/index.nginx-debian.html
     state: absent
+
+- name: Detect the installed PHP version
+  ansible.builtin.command: php -r "echo PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION;"
+  register: nginx_php_version
+  changed_when: false
+
+- name: Deploy the nginx site config
+  ansible.builtin.template:
+    src: default.j2
+    dest: /etc/nginx/sites-available/default
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload nginx

--- a/ansible/roles/nginx/templates/default.j2
+++ b/ansible/roles/nginx/templates/default.j2
@@ -10,7 +10,7 @@ server {
 
         location ~ \.php$ {
                 include snippets/fastcgi-php.conf;
-                fastcgi_pass unix:/var/run/php/php7.2-fpm.sock;
+                fastcgi_pass unix:/run/php/php{{ nginx_php_version.stdout }}-fpm.sock;
         }
 
         location ~ /\.ht {

--- a/ansible/server.yml
+++ b/ansible/server.yml
@@ -4,6 +4,6 @@
   become: true
 
   roles:
-    - nginx
     - php
+    - nginx
     - permissions

--- a/packer/server.pkr.hcl
+++ b/packer/server.pkr.hcl
@@ -68,15 +68,6 @@ build {
   }
 
   provisioner "file" {
-    source      = "../ansible/roles/nginx/templates/default"
-    destination = "/home/ubuntu/default"
-  }
-
-  provisioner "shell" {
-    inline = ["sudo mv /home/ubuntu/default /etc/nginx/sites-available/default"]
-  }
-
-  provisioner "file" {
     source      = "../app/php/src/index.php"
     destination = "/var/www/html/"
   }


### PR DESCRIPTION
Closes #27

The nginx config hardcoded `php7.2-fpm.sock`, so every request 502'd on a modern Ubuntu. It's now an Ansible template that detects the installed PHP version and sets `fastcgi_pass` accordingly. Ansible deploys the config (with a reload handler) instead of Packer copying a static file, and the php role runs before nginx so the version is known.