### PR TITLE
Add ansible.cfg and requirements.yml

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+roles_path = roles
+stdout_callback = yaml
+deprecation_warnings = True
+retry_files_enabled = False

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,5 @@
+---
+# The roles use only ansible.builtin modules, which ship with ansible-core,
+# so there are no external collections to install today. Add any Galaxy
+# collections here and run `ansible-galaxy collection install -r requirements.yml`.
+collections: []


### PR DESCRIPTION
Closes #26

An ansible.cfg with sensible defaults (roles_path, yaml callback) and a requirements.yml as the place to declare Galaxy collections. The roles only use ansible.builtin today, so the collection list is empty.