### PR TITLE
Refresh the verification profile for CINC Auditor

### DIFF
--- a/inspec/controls/nginx.rb
+++ b/inspec/controls/nginx.rb
@@ -1,29 +1,39 @@
-# Author: Gordon Murray
-# Target OS: Ubuntu
-title 'Ensure Nginx is set up correctly'
+# Verify the example web server build.
+title 'example.com web server'
 
-    describe service('nginx') do
-        it { should be_installed }
-        it { should be_enabled }
-        it { should be_running }
-    end
+describe package('nginx') do
+  it { should be_installed }
+end
 
-    describe port(80) do
-        it { should be_listening }
-    end
+describe service('nginx') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
 
-    describe port(443) do
-        it { should_not be_listening }
-    end
+describe port(80) do
+  it { should be_listening }
+end
 
-    describe file('/var/www/html/index.nginx-debian.html') do
-        it { should_not exist }
-    end
+describe port(443) do
+  it { should_not be_listening }
+end
 
-    describe bash('php -v') do
-        its('exit_status') { should eq 0 }
-    end
+describe file('/var/www/html/index.nginx-debian.html') do
+  it { should_not exist }
+end
 
-    describe file('/var/www/html/index.php') do
-        it { should exist }
-    end
+describe file('/var/www/html/index.php') do
+  it { should exist }
+end
+
+# PHP should be 8.x, whatever minor the distro ships.
+describe command('php -r "echo PHP_MAJOR_VERSION;"') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should cmp 8 }
+end
+
+# A PHP-FPM socket should exist, without hardcoding the version.
+describe command('ls /run/php/php*-fpm.sock') do
+  its('exit_status') { should eq 0 }
+end

--- a/inspec/inspec.yml
+++ b/inspec/inspec.yml
@@ -1,8 +1,8 @@
-name: example.com
+name: example
 title: example.com
 maintainer: Gordon Murray
-license: None
-summary: InSpec controls for example.com
-version: 0.0.1
+license: MIT
+summary: CINC Auditor / InSpec controls for the example web server
+version: 0.1.0
 supports:
-  - os-family: linux
+  - platform-family: debian


### PR DESCRIPTION
Closes #29

The Packer build already runs the checks with CINC Auditor (the open-source InSpec) since the HCL2 conversion. This refreshes the profile itself: real license and modern `platform-family` metadata, plus controls that assert PHP 8.x and the presence of a php-fpm socket without hardcoding a minor version.