### PR TITLE
Remove the Route53 hosted zone and CNAME

### DIFF
--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -1,4 +1,0 @@
-# route53 zones
-resource "aws_route53_zone" "example_zone" {
-  name = "myexample.com"
-}

--- a/terraform/route53_route.tf
+++ b/terraform/route53_route.tf
@@ -1,7 +1,0 @@
-resource "aws_route53_record" "example_cname" {
-  zone_id = aws_route53_zone.example_zone.zone_id
-  name    = "www.myexample.com"
-  type    = "CNAME"
-  ttl     = "60"
-  records = [aws_instance.example.public_dns]
-}


### PR DESCRIPTION
Closes #30

Drops `route53.tf` and `route53_route.tf`. They created a public hosted zone for `myexample.com` (a domain nobody owns) costing ~$0.50/month, plus a CNAME to the instance. The `public_dns` output is enough for the demo.