### PR TITLE
Default to a current-generation instance type

### DIFF
--- a/packer/server.pkr.hcl
+++ b/packer/server.pkr.hcl
@@ -18,7 +18,7 @@ variable "region" {
 
 variable "instance_type" {
   type    = string
-  default = "t2.nano"
+  default = "t3.micro"
 }
 
 # Credentials come from the standard AWS chain (AWS_PROFILE / env vars).

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -4,7 +4,7 @@
 aws_account_id = ""
 
 # EC2 instance type
-default_instance_type = "t2.nano"
+default_instance_type = "t3.micro"
 
 # Region is optional; defaults to eu-west-1 (or set AWS_REGION)
 # region = "eu-west-1"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -11,8 +11,9 @@ variable "aws_account_id" {
 }
 
 variable "default_instance_type" {
-  // EC2 instance type; read from terraform.tfvars
-  type = string
+  // EC2 instance type; override in terraform.tfvars
+  type    = string
+  default = "t3.micro"
 }
 
 variable "ssh_public_key_path" {


### PR DESCRIPTION
Closes #32

t2.nano is previous-generation. Default to t3.micro (current-gen burstable) in the Terraform variable, the tfvars example, and the Packer template.