### PR TITLE
Add an infracost cost estimate to the README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PACKER_VERSION=1.11.2 \
     TFLINT_VERSION=0.53.0 \
     TRIVY_VERSION=0.58.0 \
+    INFRACOST_VERSION=0.10.44 \
     PIPX_HOME=/opt/pipx \
     PIPX_BIN_DIR=/usr/local/bin
 
@@ -35,6 +36,10 @@ RUN pipx install --include-deps ansible && pipx install ansible-lint
 
 # CINC Auditor (the open-source InSpec distribution)
 RUN curl -fsSL https://omnitruck.cinc.sh/install.sh | bash -s -- -P cinc-auditor
+
+# Infracost (cost estimates; needs an API key at runtime)
+RUN curl -fsSL "https://github.com/infracost/infracost/releases/download/v${INFRACOST_VERSION}/infracost-linux-amd64.tar.gz" -o /tmp/ic.tgz \
+    && tar -xzf /tmp/ic.tgz -C /tmp && mv /tmp/infracost-linux-amd64 /usr/local/bin/infracost && rm /tmp/ic.tgz
 
 WORKDIR /work
 CMD ["bash"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 IMAGE ?= packer-ansible-inspec-terraform-aws-tools
 TF    := terraform -chdir=terraform
 
-.PHONY: help fmt fmt-check validate tflint ansible-lint packer-validate lint tools-build shell
+.PHONY: help fmt fmt-check validate tflint ansible-lint packer-validate lint cost tools-build shell
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -27,6 +27,9 @@ packer-validate: ## Validate the Packer template
 	cd packer && packer init . && packer validate .
 
 lint: tflint ansible-lint ## Run all linters
+
+cost: ## Estimate the monthly cost with infracost
+	infracost breakdown --path terraform
 
 tools-build: ## Build the pinned toolchain image
 	docker build -t $(IMAGE) .

--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,22 @@ public DNS is printed as an output — open it in a browser to see the page.
 - `ssh_cidr` — set to a CIDR to open SSH (port 22) to just that range. Empty by
   default, so no SSH rule is created.
 
+## Cost
+
+Roughly **$9/month** to run in `eu-west-1`, estimated with
+[Infracost](https://www.infracost.io/):
+
+| Resource | Monthly cost |
+| --- | --- |
+| EC2 instance (`t3.micro`, on-demand) | $8.32 |
+| Root EBS volume (8 GB) | $0.88 |
+| VPC, subnets, internet gateway, route tables, security group, key pair | free |
+| **Total** | **~$9.20** |
+
+Usage-based costs such as data transfer aren't included, and prices vary by
+region and over time. Regenerate the breakdown with `make cost` (needs a free
+[Infracost API key](https://dashboard.infracost.io)).
+
 ## Checks
 
 ```sh


### PR DESCRIPTION
Adds a Cost section to the README with an infracost breakdown (about $9/month in eu-west-1: t3.micro + 8 GB root volume, everything else free), a `make cost` target, and infracost in the pinned toolchain image so `make cost` works in `make shell`.