### PR TITLE
Install php-fpm/cli directly so apache2 isn't pulled in

### DIFF
--- a/ansible/roles/php/tasks/main.yml
+++ b/ansible/roles/php/tasks/main.yml
@@ -1,7 +1,8 @@
+# Install the FPM and CLI SAPIs directly. The bare "php" metapackage pulls in
+# libapache2-mod-php, which drags in apache2 and takes port 80 from nginx.
 - name: Install PHP and some related packages
   ansible.builtin.apt:
     name:
-      - php
       - php-fpm
       - php-cli
       - php-curl


### PR DESCRIPTION
Found during a real build: the nginx reload handler failed because apache2 was already on port 80. The bare `php` metapackage depends on `libapache2-mod-php`, which pulls in apache2. Installing `php-fpm php-cli php-curl` directly avoids it (verified: 0 apache2 packages, php CLI still present, php-fpm socket created).